### PR TITLE
Keep calendar widget size consistent

### DIFF
--- a/app-region/eventkit-controller.sh
+++ b/app-region/eventkit-controller.sh
@@ -11,7 +11,7 @@
 
 
 ##### @interface #####
-# Optionally set the `BTT_SYS_ROOT` environment variable to the internal system 
+# Optionally set the `BTT_SYS_ROOT` environment variable to the internal system
 # folder used by services to save and share state. Defaults to `~/.btt`
 sys_root_arg=${1:-${BTT_SYS_ROOT}}
 btt_sys_root=${sys_root_arg:-~/.btt}
@@ -23,7 +23,7 @@ status_filepath="${status_directory}/status"
 
 current_status="$(cat ${status_filepath})"
 if [[ -n "${current_status}" ]]; then
-	echo "${current_status}"
+	echo "${current_status}" | awk "{str = \$0; if (length > 33) print substr(str, 1, 15) \"...\" substr(str, length - 14, 15); else print str}"
 else
 	echo 'Calendar error'
 fi

--- a/tests/eventkit-controller-tests.bats
+++ b/tests/eventkit-controller-tests.bats
@@ -42,14 +42,15 @@ function tear_down() {
 @test 'message equals long status' {
 	set_up
 
-	# Given the status is non-empty
+	# Given the status is too long
 	local message='Some long meeting name that does not fit in 3.1 hrs'
 	local expected_result='Some long meeti... fit in 3.1 hrs'
 	echo "$message" > "${test_status_filepath}"
 	# When the controller is run
 	local message
 	message="$($eventkit_controller ${test_status_root_directory})"
-	# Then it should be the same non-empty status.
+	# Then it should be the same with three dots in between
+	# the first and last 15 characters
 	[ "${message}" = "${expected_result}" ]
 
 	tear_down

--- a/tests/eventkit-controller-tests.bats
+++ b/tests/eventkit-controller-tests.bats
@@ -39,6 +39,22 @@ function tear_down() {
 	tear_down
 }
 
+@test 'message equals long status' {
+	set_up
+
+	# Given the status is non-empty
+	local message='Some long meeting name that does not fit in 3.1 hrs'
+	local expected_result='Some long meeti... fit in 3.1 hrs'
+	echo "$message" > "${test_status_filepath}"
+	# When the controller is run
+	local message
+	message="$($eventkit_controller ${test_status_root_directory})"
+	# Then it should be the same non-empty status.
+	[ "${message}" = "${expected_result}" ]
+
+	tear_down
+}
+
 @test 'error message for empty status' {
 	set_up
 


### PR DESCRIPTION
## Goal of this PR

This PR aims at keeping the size of the event widget consistent by making it have a maximum width. It became obvious that it was necessary when my event `Updated invitation: Canceled: Brendan Le Glaunec and <***>` took over most of my bar.

## Implementation

This simply uses an awk command which prints the string if it's less than 33 char long, and uses `printf` to display it's parts separated by `...` otherwise. Awk is very fast and simple to use, so if needed, feel free to improve on this, it's my first time writing an Awk program and I didn't have access to the internet at the time, so it's almost sure that there are ways to make this better 🙂 

I added a test for the long strings but I'm not familiar with `bats` files so I'm not sure how to run them and I won't have time to look into it today. Let me know if I need to change something there.

## Screenshots

If the string for the event widget's size is less than 33 characters long, it is displayed in it's full form

<img width="1085" alt="touch bar shot 2018-09-30 at 04 22 06" src="https://user-images.githubusercontent.com/6976628/46252401-8a41a180-c468-11e8-8e77-eb6fd104a118.png">

If it is longer, it is cut by three dots, keeping the first 15 characters to identify the event itself, and the last 15 to identify the time at which it will happen/end.

<img width="1085" alt="touch bar shot 2018-09-30 at 04 21 54" src="https://user-images.githubusercontent.com/6976628/46252422-af361480-c468-11e8-9d41-de13cffb2167.png">

Feel free to play with those values to match the experience you want.